### PR TITLE
FKED-49: Logout route/component

### DIFF
--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -66,6 +66,6 @@ export function* userSetRole(role) {
 
 export function* watchUserActions() {
   yield takeLatest(USER_LOG_IN, userLogIn);
-  yield takeLatest(USER_LOG_OUT, userLogIn);
-  yield takeLatest(USER_SET_ROLE, userLogIn);
+  yield takeLatest(USER_LOG_OUT, userLogOut);
+  yield takeLatest(USER_SET_ROLE, userSetRole);
 }

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -46,7 +46,7 @@ export function* userLogIn({ username, password }) {
  */
 export function* userLogOut() {
   yield put({
-    type: USER_LOG_OUT
+    type: `${USER_LOG_OUT}_SUCCESS`
   });
 }
 
@@ -57,7 +57,7 @@ export function* userLogOut() {
  */
 export function* userSetRole(role) {
   yield put({
-    type: USER_SET_ROLE,
+    type: `${USER_SET_ROLE}_SUCCESS`,
     payload: {
       role
     }

--- a/src/actions/user.test.js
+++ b/src/actions/user.test.js
@@ -59,7 +59,7 @@ describe('actions->user', () => {
     testSaga(userLogOut)
       .next()
       .put({
-        type: USER_LOG_OUT
+        type: `${USER_LOG_OUT}_SUCCESS`
       })
       .next()
       .isDone();
@@ -69,7 +69,7 @@ describe('actions->user', () => {
     testSaga(userSetRole, USER_ROLE_EDITOR)
       .next()
       .put({
-        type: USER_SET_ROLE,
+        type: `${USER_SET_ROLE}_SUCCESS`,
         payload: {
           role: USER_ROLE_EDITOR
         }

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -22,13 +22,13 @@ const App = () => (
           redirectTo="/dashboard"
           component={Login}
         />
+        <PrivateRoute exact path="/logout" redirectTo="/" component={Logout} />
         <PrivateRoute
           exact
           path="/dashboard"
           redirectTo="/login"
           component={Dashboard}
         />
-        <PrivateRoute exact path="/logout" redirectTo="/" component={Logout} />
       </Switch>
     </Router>
   </Fragment>

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -7,7 +7,7 @@ import React, { Fragment } from 'react';
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import { CssBaseline } from '@material-ui/core';
 
-import { Home, Login, Dashboard } from '../../pages';
+import { Home, Login, Logout, Dashboard } from '../../pages';
 import { PrivateRoute, PublicRoute } from '../../hoc';
 
 const App = () => (
@@ -28,6 +28,7 @@ const App = () => (
           redirectTo="/login"
           component={Dashboard}
         />
+        <PrivateRoute exact path="/logout" redirectTo="/" component={Logout} />
       </Switch>
     </Router>
   </Fragment>

--- a/src/pages/Logout/Logout.container.js
+++ b/src/pages/Logout/Logout.container.js
@@ -10,6 +10,6 @@ const mapDispatchToProps = dispatch => ({
   dispatch
 });
 
-const mapState = () => ({});
+const mapState = ({ user }) => ({ user });
 
 export default connect(mapState, mapDispatchToProps)(Logout);

--- a/src/pages/Logout/Logout.container.js
+++ b/src/pages/Logout/Logout.container.js
@@ -1,0 +1,15 @@
+/**
+ * @file Logout.container.js
+ * Exports a redux-connected Logout component.
+ */
+
+import { connect } from 'react-redux';
+import Logout from './Logout';
+
+const mapDispatchToProps = dispatch => ({
+  dispatch
+});
+
+const mapState = () => ({});
+
+export default connect(mapState, mapDispatchToProps)(Logout);

--- a/src/pages/Logout/Logout.js
+++ b/src/pages/Logout/Logout.js
@@ -1,0 +1,31 @@
+/**
+ * @file Logout.js
+ * Exports a React component that handles requests to /logout.
+ */
+
+import { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import { USER_LOG_OUT } from '../../constants';
+
+class Logout extends Component {
+  static propTypes = {
+    dispatch: PropTypes.func.isRequired
+  };
+
+  /**
+   * {@inheritdoc}
+   */
+  componentWillMount() {
+    this.props.dispatch({ type: USER_LOG_OUT });
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  render() {
+    return null;
+  }
+}
+
+export default Logout;

--- a/src/pages/Logout/Logout.test.js
+++ b/src/pages/Logout/Logout.test.js
@@ -1,0 +1,37 @@
+/**
+ * @file Logout.test.js
+ * Contains tests for Logout.js.
+ */
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+import configureStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
+import { MemoryRouter as Router } from 'react-router-dom';
+
+import Logout from './Logout.container';
+
+describe('<Logout />', () => {
+  it('Matches its snapshot', () => {
+    const store = configureStore()({
+      user: {
+        uid: '1',
+        authentication: {
+          accessToken: 'test',
+          csrfToken: 'test'
+        }
+      }
+    });
+    expect(
+      renderer
+        .create(
+          <Provider store={store}>
+            <Router>
+              <Logout />
+            </Router>
+          </Provider>
+        )
+        .toJSON()
+    ).toMatchSnapshot();
+  });
+});

--- a/src/pages/Logout/__snapshots__/Logout.test.js.snap
+++ b/src/pages/Logout/__snapshots__/Logout.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Logout /> Matches its snapshot 1`] = `null`;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -5,6 +5,7 @@
 
 import Home from './Home/Home';
 import Login from './Login/Login';
+import Logout from './Logout/Logout.container';
 import Dashboard from './Dashboard/Dashboard.container';
 
-export { Home, Login, Dashboard };
+export { Home, Login, Logout, Dashboard };

--- a/src/reducers/__snapshots__/user.test.js.snap
+++ b/src/reducers/__snapshots__/user.test.js.snap
@@ -51,7 +51,7 @@ Object {
 }
 `;
 
-exports[`reducers->user Should handle USER_LOG_OUT 1`] = `
+exports[`reducers->user Should handle USER_LOG_OUT_SUCCESS 1`] = `
 Object {
   "authentication": Object {
     "accessToken": null,
@@ -68,7 +68,7 @@ Object {
 }
 `;
 
-exports[`reducers->user Should handle USER_SET_ROLE 1`] = `
+exports[`reducers->user Should handle USER_SET_ROLE_SUCCESS 1`] = `
 Object {
   "authentication": Object {
     "accessToken": null,

--- a/src/reducers/user.js
+++ b/src/reducers/user.js
@@ -92,7 +92,7 @@ export default function user(state = defaultState, action) {
      * Reducer that handles user logout actions.
      */
     case USER_LOG_OUT: {
-      return defaultState;
+      return { ...defaultState };
     }
 
     /**

--- a/src/reducers/user.js
+++ b/src/reducers/user.js
@@ -91,14 +91,14 @@ export default function user(state = defaultState, action) {
     /**
      * Reducer that handles user logout actions.
      */
-    case USER_LOG_OUT: {
-      return { ...defaultState };
+    case `${USER_LOG_OUT}_SUCCESS`: {
+      return defaultState;
     }
 
     /**
      * Reducer that handles setting a user's role.
      */
-    case USER_SET_ROLE: {
+    case `${USER_SET_ROLE}_SUCCESS`: {
       const { role } = action.payload;
       return { ...state, authentication: { ...state.authentication, role } };
     }

--- a/src/reducers/user.test.js
+++ b/src/reducers/user.test.js
@@ -61,18 +61,18 @@ describe('reducers->user', () => {
     ).toMatchSnapshot();
   });
 
-  it(`Should handle ${USER_LOG_OUT}`, () => {
+  it(`Should handle ${USER_LOG_OUT}_SUCCESS`, () => {
     expect(
       reducer(undefined, {
-        type: USER_LOG_OUT
+        type: `${USER_LOG_OUT}_SUCCESS`
       })
     ).toMatchSnapshot();
   });
 
-  it(`Should handle ${USER_SET_ROLE}`, () => {
+  it(`Should handle ${USER_SET_ROLE}_SUCCESS`, () => {
     expect(
       reducer(undefined, {
-        type: USER_SET_ROLE,
+        type: `${USER_SET_ROLE}_SUCCESS`,
         payload: {
           role: USER_ROLE_EDITOR
         }


### PR DESCRIPTION
## [FKED-49: Logout](https://fourkitchens.atlassian.net/browse/FKED-49)

**This PR does the following:**
- Adds a route for loading the new logout component, that triggers the logout action/reducer

### To Review:
- [x] Checkout this branch.
- [x] Run `yarn start`.
- [x] Login
- [x] At the dashboard, click logout
- [x] See that you're logged out, redirected to the home page and must login again.
