### PR TITLE
FKED-84: Number input form validation bugs

### DIFF
--- a/src/components/ComponentForm/ComponentForm.js
+++ b/src/components/ComponentForm/ComponentForm.js
@@ -5,7 +5,7 @@
 
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { string, object, mixed } from 'yup';
+import { string, object, number } from 'yup';
 import { withFormik } from 'formik';
 import {
   withStyles,
@@ -266,6 +266,7 @@ class ComponentForm extends Component {
               : 'Use this field to set the positional X coordinate for this component'
           }
           value={values.field_x}
+          inputProps={{ step: 'any' }}
           onChange={this.handleChange}
           onBlur={handleBlur}
           error={!!errors.field_x && touched.field_x}
@@ -283,6 +284,7 @@ class ComponentForm extends Component {
               : 'Use this field to set the positional Y coordinate for this component'
           }
           value={values.field_y}
+          inputProps={{ step: 'any' }}
           onChange={this.handleChange}
           onBlur={handleBlur}
           error={!!errors.field_y && touched.field_y}
@@ -300,6 +302,7 @@ class ComponentForm extends Component {
               : 'Use this field to set the positional Z coordinate for this component'
           }
           value={values.field_z}
+          inputProps={{ step: 'any' }}
           onChange={this.handleChange}
           onBlur={handleBlur}
           error={!!errors.field_z && touched.field_z}
@@ -391,9 +394,15 @@ const FormikComponentForm = withFormik({
       .required()
       .min(3)
       .max(200),
-    field_x: mixed(),
-    field_y: mixed(),
-    field_z: mixed()
+    field_x: number()
+      .min(-6)
+      .max(6),
+    field_y: number()
+      .min(-3)
+      .max(6),
+    field_z: number()
+      .min(-6)
+      .max(6)
   }),
   handleSubmit: (values, { props, setSubmitting }) => {
     const {

--- a/src/components/SceneRotationForm/SceneRotationForm.js
+++ b/src/components/SceneRotationForm/SceneRotationForm.js
@@ -5,7 +5,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { object, mixed } from 'yup';
+import { object, number } from 'yup';
 import { withFormik } from 'formik';
 import { withStyles, TextField, Button } from '@material-ui/core';
 
@@ -132,6 +132,7 @@ class SceneRotationForm extends Component {
               : 'Use this field to set the X value for this scenes sky rotation.'
           }
           value={values.field_sky_rotation_x}
+          inputProps={{ step: '0.5' }}
           onChange={this.handleChange}
           onBlur={handleBlur}
           error={!!errors.field_sky_rotation_x && touched.field_sky_rotation_x}
@@ -149,6 +150,7 @@ class SceneRotationForm extends Component {
               : 'Use this field to set the Y value for this scenes sky rotation.'
           }
           value={values.field_sky_rotation_y}
+          inputProps={{ step: '0.5' }}
           onChange={this.handleChange}
           onBlur={handleBlur}
           error={!!errors.field_sky_rotation_y && touched.field_sky_rotation_y}
@@ -166,6 +168,7 @@ class SceneRotationForm extends Component {
               : 'Use this field to set the Z value for this scenes sky rotation.'
           }
           value={values.field_sky_rotation_z}
+          inputProps={{ step: '0.5' }}
           onChange={this.handleChange}
           onBlur={handleBlur}
           error={!!errors.field_sky_rotation_z && touched.field_sky_rotation_z}
@@ -212,9 +215,15 @@ const FormikSceneRotationForm = withFormik({
     };
   },
   validationSchema: object().shape({
-    field_sky_rotation_x: mixed(),
-    field_sky_rotation_y: mixed(),
-    field_sky_rotation_z: mixed()
+    field_sky_rotation_x: number()
+      .min(-180)
+      .max(180),
+    field_sky_rotation_y: number()
+      .min(-180)
+      .max(180),
+    field_sky_rotation_z: number()
+      .min(-180)
+      .max(180)
   }),
   handleSubmit: (values, { props, setSubmitting }) => {
     const {


### PR DESCRIPTION
## [FKED-84: Clientside field validation needs adjustment](https://fourkitchens.atlassian.net/browse/FKED-84)

**This PR does the following:**
- Previously when numbers were changed on forms, the type set on the text fields triggered HTML5 DOM/Browser form validation which couldn't validate the input without a number step value and would prevent the form from submitting, sidestepping formik/yup validation.
- This adds correct `number()` yup validation with min/max instead of generic `mixed()` for number fields, as well as adding required `step` field property for the TextField components. Future decimal input number fields should continue to use this pattern to prevent blocking issues.

### To Review:
- [ ] Checkout this branch.
- [ ] Run `yarn start`.
- [ ] Login and edit any test experience, scene, and component
- [ ] Edit any number field and see that the values are limited by yup, but you are not blocked from submitting the form after minor adjustments to high precision decimal values
- [ ] Do the same for scene background rotation, each axis should be locked to 0.5 degree increments, and limited to the range of -180 to 180.
